### PR TITLE
Fix validation issue for maxAge greater than 2^31

### DIFF
--- a/lib/connect-tedious.js
+++ b/lib/connect-tedious.js
@@ -16,9 +16,9 @@ var debug={
 };
 
 /**
- * One day in seconds.
+ * One day in milliseconds.
  */
-var oneDay = 86400;
+var oneDay = 86400 * 1000;
 
 function debugSql(r) {
     if (!r || !debug.sql.enabled)
@@ -217,8 +217,8 @@ module.exports = function(connect) {
                 var r = new tedious.Request(
                     'MERGE INTO ' + self.tableName + ' WITH (HOLDLOCK) s' +
                     '  USING (VALUES(@sid, @sess)) ns(' + self.sidColumnName + ', ' + self.sessColumnName + ') ON (s.' + self.sidColumnName + '=ns.' + self.sidColumnName + ')' +
-                    '  WHEN MATCHED THEN UPDATE SET s.' + self.sessColumnName + '=@sess, s.' + self.expiresColumnName + '=DATEADD(ms, @duration, SYSUTCDATETIME())' +
-                    '  WHEN NOT MATCHED THEN INSERT (' + self.sidColumnName + ', ' + self.sessColumnName + ', ' + self.expiresColumnName + ') VALUES (@sid, @sess, DATEADD(ms, @duration, SYSUTCDATETIME()));',
+                    '  WHEN MATCHED THEN UPDATE SET s.' + self.sessColumnName + '=@sess, s.' + self.expiresColumnName + '=DATEADD(ss, @duration, SYSUTCDATETIME())' +
+                    '  WHEN NOT MATCHED THEN INSERT (' + self.sidColumnName + ', ' + self.sessColumnName + ', ' + self.expiresColumnName + ') VALUES (@sid, @sess, DATEADD(ss, @duration, SYSUTCDATETIME()));',
                     function(err) {
                         debug.sql('Executed MERGE');
                         db.release();
@@ -230,7 +230,7 @@ module.exports = function(connect) {
                 );
                 r.addParameter('sid', tedious.TYPES.VarChar, sid);
                 r.addParameter('sess', tedious.TYPES.NVarChar, JSON.stringify(sess));
-                r.addParameter('duration', tedious.TYPES.Int, duration);
+                r.addParameter('duration', tedious.TYPES.Int, duration / 1000);
 
                 debugSql(r);
                 db.execSql(r);
@@ -370,7 +370,7 @@ module.exports = function(connect) {
                 var duration = sess.cookie.maxAge || oneDay;
 
                 var r = new tedious.Request(
-                    'UPDATE ' + self.tableName + ' SET ' + self.expiresColumnName + '=DATEADD(ms, @duration, SYSUTCDATETIME()) WHERE ' + self.sidColumnName + '=@sid',
+                    'UPDATE ' + self.tableName + ' SET ' + self.expiresColumnName + '=DATEADD(ss, @duration, SYSUTCDATETIME()) WHERE ' + self.sidColumnName + '=@sid',
                     function (err) {
                         debug.sql('Executed UPDATE');
                         db.release();
@@ -380,7 +380,7 @@ module.exports = function(connect) {
                         fn(null, true);
                     }
                 );
-                r.addParameter('duration', tedious.TYPES.Int, duration);
+                r.addParameter('duration', tedious.TYPES.Int, duration / 1000);
                 r.addParameter('sid', tedious.TYPES.VarChar, sid);
 
                 debugSql(r);


### PR DESCRIPTION
If you have a cookie with the maxAge to a value larger than 2^31 it causes the SQL queries updating the expiration date to not validate properly. Now we convert the duration in seconds before passing it to the query.